### PR TITLE
Initial testing approach for optimizers.

### DIFF
--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -1,12 +1,11 @@
 import pytest
 from hydra.utils import get_class, instantiate
 from omegaconf import OmegaConf
-from typing import List
-from torch import Tensor
 
 from torch.optim import *
 from config.torch.optim import *
 
+from torch import Tensor
 from torch import nn
 model = nn.Linear(20, 30)
 
@@ -25,4 +24,8 @@ def test_instantiate_classes(
     schema = OmegaConf.structured(get_class(full_class))
     cfg = OmegaConf.merge(schema, cfg)
     obj = instantiate(cfg, **passthrough_kwargs)
-    # assert obj == expected
+
+    def closure():
+        return Tensor([10])
+    assert obj.step(closure) == expected.step(closure)
+

--- a/tests/test_instantiate.py
+++ b/tests/test_instantiate.py
@@ -5,9 +5,10 @@ from omegaconf import OmegaConf
 from torch.optim import *
 from config.torch.optim import *
 
+import torch
 from torch import Tensor
 from torch import nn
-model = nn.Linear(20, 30)
+model = nn.Linear(1, 2)
 
 @pytest.mark.parametrize(
     "classname, cfg, passthrough_kwargs, expected",
@@ -26,6 +27,6 @@ def test_instantiate_classes(
     obj = instantiate(cfg, **passthrough_kwargs)
 
     def closure():
-        return Tensor([10])
-    assert obj.step(closure) == expected.step(closure)
+        return model(Tensor([10]))
+    assert torch.all(torch.eq(obj.step(closure), expected.step(closure)))
 


### PR DESCRIPTION
Tests Adam and AdamW instantiations by initializing two optimizers. One from the generated config and one from an expected config. The test then calls `optimizer.step()` on simple model and compares the outputs.

If this looks good, I'll use this method across all optimizers.